### PR TITLE
CIR-2758 Uplift to fix violation vulnerabilities

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "10.5.0"
+  private val bootstrapVersion = "10.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion


### PR DESCRIPTION
This pull request makes a minor update to the project's dependencies. The version of the `bootstrap-backend-play-30` library has been updated from 10.5.0 to 10.6.0 in `AppDependencies.scala` to address CVE's